### PR TITLE
Use working version constraint for TYPO3 v10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,8 +28,8 @@
         "typo3-ter/hh_ckeditor_custom": "self.version"
     },
     "require": {
-        "typo3/cms-core": "^8.7.1 || ^10.4.99",
-        "typo3/cms-rte-ckeditor": "^8.7.7 || ^10.4.99"
+        "typo3/cms-core": "^8.7.1 || ^10.4",
+        "typo3/cms-rte-ckeditor": "^8.7.7 || ^10.4"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -28,8 +28,8 @@
         "typo3-ter/hh_ckeditor_custom": "self.version"
     },
     "require": {
-        "typo3/cms-core": "^8.7.1 || ^10.4",
-        "typo3/cms-rte-ckeditor": "^8.7.7 || ^10.4"
+        "typo3/cms-core": "^8.7.7 || ^9.5 || ^10.4",
+        "typo3/cms-rte-ckeditor": "^8.7.7 || ^9.5 || ^10.4"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
With "^10.4" you can handle all v10 installations, with "^10.4.99" currently no one.